### PR TITLE
Update image version to 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM ruby:2.6.5-alpine
 
 # These are needed to support building native extensions during
 # bundle install step

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 IMAGE := cloud-platform-slack-answerbot
-VERSION := 1.5
+VERSION := 1.6
 ORG := ministryofjustice
 TAGGED := $(ORG)/$(IMAGE):$(VERSION)
 
@@ -9,7 +9,7 @@ clean:
 	docker rmi $(IMAGE) --force
 	docker rmi $(TAGGED) --force
 	rm .built-docker-image
-	
+
 .built-docker-image: Dockerfile Gemfile Rakefile config.ru config/environment.rb bin/run.rb $(wildcard lib/*.rb)
 	docker build -t $(IMAGE) .
 	docker tag $(IMAGE) $(TAGGED)
@@ -19,7 +19,7 @@ docker-push: .built-docker-image
 	docker push $(TAGGED)
 
 # Run a local copy of the Slack Answer bot.
-# Set the SLACK_API_TOKEN as environment variable. 
+# Set the SLACK_API_TOKEN as environment variable.
 # The SLACK_API_TOKEN is the OAuth token for the bot user staring with xoxb provided in OAuth permissions of slack settings
 
 server: .built-docker-image


### PR DESCRIPTION
This version includes the latest dependabot fixes, and uses ruby 2.6.5
instead of 2.6.4